### PR TITLE
CARD-5881668 Add correct state name to character action tests

### DIFF
--- a/src/reducers/__tests__/characters.test.js
+++ b/src/reducers/__tests__/characters.test.js
@@ -2,7 +2,7 @@ import * as singleAnimeCreator from 'actions/singleAnimeCreators';
 
 import characters from '../characters';
 
-const initialStateAnimeList = Object.freeze({
+const initialAnimeCharacters = Object.freeze({
   isFeching: false,
   characters: [],
   error: false,
@@ -11,23 +11,23 @@ const initialStateAnimeList = Object.freeze({
 
 describe('characters reducers', () => {
   it('should return the default state', () => {
-    expect(characters(undefined, {})).toEqual(initialStateAnimeList);
+    expect(characters(undefined, {})).toEqual(initialAnimeCharacters);
   });
 
   it('should handle `REQUEST_ANIME_CHARACTERS`', () => {
     const expected = {
-      ...initialStateAnimeList,
+      ...initialAnimeCharacters,
       isFeching: true,
     };
 
     expect(
-      characters(initialStateAnimeList, singleAnimeCreator.requestCharacters()),
+      characters(initialAnimeCharacters, singleAnimeCreator.requestCharacters()),
     ).toEqual(expected);
   });
 
   it('should handle `RECIEVE_ANIME_CHARACTERS_DATA`', () => {
     const state = Object.freeze({
-      ...initialStateAnimeList,
+      ...initialAnimeCharacters,
       isFeching: true,
     });
 
@@ -46,7 +46,7 @@ describe('characters reducers', () => {
       },
     ];
     const expected = {
-      ...initialStateAnimeList,
+      ...initialAnimeCharacters,
       isFeching: false,
       characters: charactersData,
     };
@@ -60,12 +60,12 @@ describe('characters reducers', () => {
     const errMsg = 'URL not found';
 
     const state = Object.freeze({
-      ...initialStateAnimeList,
+      ...initialAnimeCharacters,
       isFeching: true,
     });
 
     const expected = {
-      ...initialStateAnimeList,
+      ...initialAnimeCharacters,
       error: true,
       errorMessage: new Error(errMsg),
     };

--- a/src/reducers/animeList.js
+++ b/src/reducers/animeList.js
@@ -37,16 +37,12 @@ export default function animeList(state = initialStateAnimeList, action) {
       return {
         ...state,
         isFeching: true,
-        error: false,
-        errorMessage: '',
       };
     case RECIEVE_ANIMES_LIST_DATA:
       return {
         ...state,
         isFeching: false,
         animes: [...state.animes, ...action.payload.animes],
-        error: false,
-        errorMessage: '',
       };
     case REQUEST_ANIMES_LIST_FAILED:
       return {

--- a/src/reducers/singleAnime.js
+++ b/src/reducers/singleAnime.js
@@ -32,14 +32,12 @@ export default function singleAnime(state = initialStateSingleAnime, action) {
       return {
         ...state,
         isFeching: true,
-        error: false,
       };
     case RECIEVE_SINGLE_ANIME_DATA:
       return {
         ...state,
         isFeching: false,
         anime: { ...action.payload.anime },
-        error: false,
       };
     case REQUEST_SINGLE_ANIME_FAILED:
       return {


### PR DESCRIPTION
### Github Ticket(s)
<The link to the related ticket in Github.>

* [card-5881668 ](https://github.com/migueliriano/react-anime-project/projects/1#card-5881668 )

### Description
<Brief description of the code changes.>

- rename variable on action test `characters.js` with the correct name
- Remove unneeded state properties of error on reducers.