### PR TITLE
CARD-6649479 Add max width to anime grid list container

### DIFF
--- a/src/style/__tests__/__snapshots__/animeGridList.test.js.snap
+++ b/src/style/__tests__/__snapshots__/animeGridList.test.js.snap
@@ -14,6 +14,8 @@ exports[`animeGridList style components Should render a GridContainer Component 
   -ms-flex-pack: space-evenly;
   justify-content: space-evenly;
   padding: 30px;
+  max-width: 1600px;
+  margin: 0 auto;
 }
 
 <section

--- a/src/style/animeGridList.js
+++ b/src/style/animeGridList.js
@@ -13,6 +13,8 @@ const GridContainer = Styled.section`
   flex-wrap: wrap;
   justify-content: space-evenly;
   padding: 30px;
+  max-width: 1600px;
+  margin: 0 auto;
 `;
 
 export default GridContainer;


### PR DESCRIPTION
### Github Ticket(s)
<The link to the related ticket on Github.>

* [CARD-6649479 ](https://github.com/migueliriano/react-anime-project/projects/1#card-6649479 )

### Description
<Brief description of the code changes.>
Add max width to anime grid list container